### PR TITLE
support pathType customization

### DIFF
--- a/aidbox/templates/ingress.yaml
+++ b/aidbox/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: ImplementationSpecific
+            pathType: {{ .Values.ingress.pathType | default "ImplementationSpecific" | quote }}
             backend:
               service:
                 name: {{ $fullName }}-api


### PR DESCRIPTION
We intend to use aidbox with the [aws-load-balancer-controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/) for ingress, but the `ImplementationSpecific` [behavior](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/e5d625f96415fd44e6399e9c75e2bd985f5a2288/pkg/ingress/model_build_listener_rules.go#L207) for that controller seems to be the same as `Exact` whereas the `nginx` ingress controller treats it as `Prefix`.

This would allow the consumer to specify the `pathType` for compatibility with their chosen ingress controller.