### PR TITLE
Add link from stateful set to service

### DIFF
--- a/aidboxdb/templates/statefulset.yaml
+++ b/aidboxdb/templates/statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "aidboxdb.labels" . | nindent 4 }}
 spec:
+  serviceName: {{ include "aidboxdb.fullname" . }}
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
Without this I get:

```
error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec
```