### PR TITLE
Add bd databse and db host in the exclusion

### DIFF
--- a/aidbox/templates/configmap.yaml
+++ b/aidbox/templates/configmap.yaml
@@ -6,7 +6,8 @@ metadata:
     {{- include "aidbox.labels" . | nindent 4 }}
 data:
   {{- range $key, $val := .Values.config }}
-  {{- if and (ne $key "BOX_DB_USER") (ne $key "BOX_DB_PASSWORD") (ne $key "BOX_ROOT_CLIENT_ID") (ne $key "BOX_ROOT_CLIENT_SECRET") (ne $key "BOX_ADMIN_ID") (ne $key "BOX_ADMIN_PASSWORD") (ne $key "AIDBOX_LICENSE") (ne $key "BOX_OBSERVABILITY_ELASTIC_SEARCH_AUTH") (ne $key "AIDBOX_SUPERUSER") (ne $key "AIDBOX_CLUSTER_SECRET") }}
+  {{- if and 
+    (ne $key "BOX_DB_USER") (ne $key "BOX_DB_PASSWORD") (ne $key "BOX_ROOT_CLIENT_ID") (ne $key "BOX_ROOT_CLIENT_SECRET") (ne $key "BOX_ADMIN_ID") (ne $key "BOX_ADMIN_PASSWORD") (ne $key "AIDBOX_LICENSE") (ne $key "BOX_OBSERVABILITY_ELASTIC_SEARCH_AUTH") (ne $key "AIDBOX_SUPERUSER") (ne $key "AIDBOX_CLUSTER_SECRET") (ne $key "BOX_DB_DATABASE") (ne $key "BOX_DB_HOST")}}
   {{ $key }}: {{ $val | quote }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
The issue : 

When building the chart, the configmap file duplicates the 2 values (BOX_DB_DATABASE and BOX_DB_HOST)

```
# Source: carepath-aidbox/charts/aidbox/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: release1-aidbox
  labels:
    helm.sh/chart: aidbox-0.2.1
    app.kubernetes.io/name: aidbox
    app.kubernetes.io/instance: release1
    app.kubernetes.io/version: "edge"
    app.kubernetes.io/managed-by: Helm
data:
  BOX_DB_DATABASE: "aidbox"
  BOX_DB_HOST: "project-postgresql-hl.project-dev-test.svc.cluster.local"
  BOX_DB_PORT: "5432"
  BOX_METRICS_PORT: "8765"
  BOX_WEB_PORT: "8080"

  BOX_DB_DATABASE: "aidbox"
  BOX_DB_HOST: "project-postgresql-hl.project-dev-test.svc.cluster.local"

```
Adding them in the exclusion avoids adding the values, but keeps the required alert and will add the values at that moment. 


